### PR TITLE
Compatibility with CoursePlay on Dediservers

### DIFF
--- a/FS22_REAimplements/REAimplements.lua
+++ b/FS22_REAimplements/REAimplements.lua
@@ -1085,7 +1085,9 @@ function REAimplements:UpdateGroundTypeNodes(ToolType,PowerConsumer,LeftNode,Rig
 
 	-- Update position of ground type nodes
 	for Index=1, NumGroundType do
-		setTranslation(PowerConsumer.GroundTypeNodes[Index],(StepX*(Index-1))+(PlowOffset*PlowOffsetDir),StepY*(Index-1),(StepZ*(Index-1))+OffsetInFront);
+		if PowerConsumer.GroundTypeNodes[Index] ~= nil then
+			setTranslation(PowerConsumer.GroundTypeNodes[Index],(StepX*(Index-1))+(PlowOffset*PlowOffsetDir),StepY*(Index-1),(StepZ*(Index-1))+OffsetInFront);
+		end
 	end;
 end
 

--- a/FS22_REAimplements/modDesc.xml
+++ b/FS22_REAimplements/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="63">
     <author>900Hasse</author>
-	<version>1.0.0.0</version>
+	<version>1.0.0.1</version>
 	<title>
         <en>REA22 Implements</en>
     </title>


### PR DESCRIPTION
Fix massive Lua-CallStacks while using CoursePlay for the field work on Dediservers:

I don't know why, but when using Courseplay on a dediserver, PowerConsumer.GroundTypeNodes seems to be nil, causing an endless count of Lua call stacks in the server's log. By checking the nil-condition before calling setTranslation, all works fine now.

#3 #6 